### PR TITLE
Remove build size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ three-particles
 
 ![](https://github.com/polyforest/three-particles/workflows/CI/badge.svg)
 [![NPM Package](https://img.shields.io/npm/v/three-particles)](https://www.npmjs.com/package/three-particles)
-[![Build Size](https://badgen.net/bundlephobia/minzip/three-particles)](https://bundlephobia.com/result?p=three-particles)
 [![NPM Downloads](https://img.shields.io/npm/dw/three-particles)](https://www.npmtrends.com/three-particles)
 
 # three-particles


### PR DESCRIPTION
Misleading when THREE.JS is 99%